### PR TITLE
feat: extract logger to a separate schema component

### DIFF
--- a/schemas/common/boilerplate/v5.schema.json
+++ b/schemas/common/boilerplate/v5.schema.json
@@ -39,28 +39,16 @@
       ],
       "properties": {
         "shared": {
-          "allOf": [{ "$ref": "https://mapcolonies.com/common/telemetry/base/v1" }, { "default": {} }]
+          "$ref": "https://mapcolonies.com/common/telemetry/base/v1"
         },
         "tracing": {
-          "allOf": [{ "$ref": "https://mapcolonies.com/common/telemetry/tracing/v1" }, { "default": {} }]
+          "$ref": "https://mapcolonies.com/common/telemetry/tracing/v1"
         },
         "logger": {
-          "description": "Logger configuration",
-          "type": "object",
-          "default": {},
-          "properties": {
-            "level": {
-              "default": "info",
-              "description": "The log level",
-              "x-env-value": "LOG_LEVEL",
-              "enum": ["trace", "debug", "info", "warn", "error", "fatal"]
-            },
-            "prettyPrint": { "default": false, "description": "Whether to pretty print logs", "type": "boolean", "x-env-value": "LOG_PRETTY_PRINT" }
-          },
-          "required": ["level", "prettyPrint"]
+          "$ref": "https://mapcolonies.com/common/telemetry/logger/v1"
         }
       },
-      "required": ["logger"]
+      "required": ["logger", "shared", "tracing"]
     },
     "server": {
       "description": "Server configuration",

--- a/schemas/common/boilerplate/v6.schema.json
+++ b/schemas/common/boilerplate/v6.schema.json
@@ -39,28 +39,16 @@
       ],
       "properties": {
         "shared": {
-          "allOf": [{ "$ref": "https://mapcolonies.com/common/telemetry/base/v1" }, { "default": {} }]
+          "$ref": "https://mapcolonies.com/common/telemetry/base/v1"
         },
         "tracing": {
-          "allOf": [{ "$ref": "https://mapcolonies.com/common/telemetry/tracing/v1" }, { "default": {} }]
+          "$ref": "https://mapcolonies.com/common/telemetry/tracing/v1"
         },
         "logger": {
-          "description": "Logger configuration",
-          "type": "object",
-          "default": {},
-          "properties": {
-            "level": {
-              "default": "info",
-              "description": "The log level",
-              "x-env-value": "LOG_LEVEL",
-              "enum": ["trace", "debug", "info", "warn", "error", "fatal"]
-            },
-            "prettyPrint": { "default": false, "description": "Whether to pretty print logs", "type": "boolean", "x-env-value": "LOG_PRETTY_PRINT" }
-          },
-          "required": ["level", "prettyPrint"]
+          "$ref": "https://mapcolonies.com/common/telemetry/logger/v1"
         }
       },
-      "required": ["logger"]
+      "required": ["logger", "shared", "tracing"]
     },
     "server": {
       "description": "Server configuration",

--- a/schemas/common/boilerplate/v6.schema.json
+++ b/schemas/common/boilerplate/v6.schema.json
@@ -2,7 +2,7 @@
   "description": "Boilerplate basic configuration",
   "$id": "https://mapcolonies.com/common/boilerplate/v6",
   "type": "object",
-  "title": "commonBoilerplateV4",
+  "title": "commonBoilerplateV6",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "required": ["openapiConfig", "telemetry", "server"],
   "properties": {

--- a/schemas/common/boilerplate/v6.schema.json
+++ b/schemas/common/boilerplate/v6.schema.json
@@ -1,6 +1,6 @@
 {
   "description": "Boilerplate basic configuration",
-  "$id": "https://mapcolonies.com/common/boilerplate/v5",
+  "$id": "https://mapcolonies.com/common/boilerplate/v6",
   "type": "object",
   "title": "commonBoilerplateV4",
   "$schema": "http://json-schema.org/draft-07/schema#",

--- a/schemas/common/telemetry/base/v1.schema.json
+++ b/schemas/common/telemetry/base/v1.schema.json
@@ -2,6 +2,7 @@
   "$id": "https://mapcolonies.com/common/telemetry/base/v1",
   "title": "commonTelemetryBaseV1",
   "description": "Telemetry base configuration",
+  "default": {},
   "type": "object",
   "properties": {
     "serviceName": {

--- a/schemas/common/telemetry/logger/v1.schema.json
+++ b/schemas/common/telemetry/logger/v1.schema.json
@@ -1,6 +1,6 @@
 {
   "$id": "https://mapcolonies.com/common/telemetry/logger/v1",
-  "title": "commonTelemetryLoggerV1",
+  "title": "telemetryLoggerV1",
   "description": "Telemetry logger configuration",
   "type": "object",
   "default": {},

--- a/schemas/common/telemetry/logger/v1.schema.json
+++ b/schemas/common/telemetry/logger/v1.schema.json
@@ -1,0 +1,36 @@
+{
+  "$id": "https://mapcolonies.com/common/telemetry/logger/v1",
+  "title": "commonTelemetryLoggerV1",
+  "description": "Telemetry logger configuration",
+  "type": "object",
+  "default": {},
+  "required": ["level", "prettyPrint"],
+  "properties": {
+    "level": {
+      "$ref": "#/definitions/level"
+    },
+    "prettyPrint": {
+      "$ref": "#/definitions/prettyPrint"
+    }
+  },
+  "examples": [
+    {
+      "level": "info",
+      "prettyPrint": false
+    }
+  ],
+  "definitions": {
+    "level": {
+      "default": "info",
+      "description": "The log level",
+      "x-env-value": "LOG_LEVEL",
+      "enum": ["trace", "debug", "info", "warn", "error", "fatal"]
+    },
+    "prettyPrint": {
+      "default": false,
+      "description": "Whether to pretty print logs",
+      "type": "boolean",
+      "x-env-value": "LOG_PRETTY_PRINT"
+    }
+  }
+}


### PR DESCRIPTION
Logger should also be defined as seperated and independant schema so the boilerplate schema will refer to it and also other schemas