### PR TITLE
refactor: remove unnecessary draft-07 meta schema import

### DIFF
--- a/scripts/validate/validate.mts
+++ b/scripts/validate/validate.mts
@@ -3,7 +3,6 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import AjvModule from 'ajv/dist/2019.js';
-import * as draft7MetaSchema from 'ajv/dist/refs/json-schema-draft-07.json' assert { type: 'json' };
 import addFormats from 'ajv-formats';
 import { $RefParser } from '@apidevtools/json-schema-ref-parser';
 import { presult, result } from '../util/index.mjs';
@@ -108,8 +107,6 @@ async function validateSchema(schema: any, file: string) {
     useDefaults: true,
     loadSchema: async (uri: string) => ({ type: 'object' }),
   });
-
-  ajv.addMetaSchema(draft7MetaSchema, 'http://json-schema.org/draft-07/schema#');
 
   // @ts-expect-error https://github.com/ajv-validator/ajv-formats/issues/85
   addFormats(ajv);


### PR DESCRIPTION
This PR removes the use of the draft 07 metaschema as it is already used.

See [this section](https://ajv.js.org/api.html#ajv-addmetaschema-schema-object-object-key-string-ajv) in Ajv