### PR TITLE
feat: extend validator keywords to include 'x-env-format'

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ export default Type.Strict(schema);
 In order to enable extra abilities and features we have added custom properties that can be added to schemas.
 
 - `x-env-value` - The value from which to pull environment variables to override the config values.
+- `x-env-format` - The format of the environment variable. Can be `json`, for primitive values, leave undefined.
 - `x-populate-as-env` - **_experimental_** Whether to place the value into the environment variable defined in `x-env-value`.
 
 ```json

--- a/scripts/validate/core.mts
+++ b/scripts/validate/core.mts
@@ -37,7 +37,7 @@ const configAjv = addFormats(
       delete schema.$id;
       return schema;
     },
-    keywords: ['x-env-value'],
+    keywords: ['x-env-value', 'x-populate-as-env', 'x-env-format'],
     useDefaults: true,
     addUsedSchema: false,
   })

--- a/scripts/validate/validate.mts
+++ b/scripts/validate/validate.mts
@@ -102,7 +102,7 @@ async function validateRefs(schema: string) {
 
 async function validateSchema(schema: any, file: string) {
   const ajv = new AjvModule.default({
-    keywords: ['x-env-value', 'x-populate-as-env'],
+    keywords: ['x-env-value', 'x-populate-as-env', 'x-env-format'],
     allErrors: true,
     discriminator: true,
     useDefaults: true,


### PR DESCRIPTION
Added support so ajv allowed the x-env-format keyword

related pull requests:
https://github.com/MapColonies/config-ui/pull/61
https://github.com/MapColonies/config-server/pull/85
https://github.com/MapColonies/config/pull/59